### PR TITLE
set and get for nMaxWorkersCount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsonrpc-bidirectional",
   "description": "Bidirectional JSONRPC over web sockets or HTTP with extensive plugin support.",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "scripts": {
     "build": "node build.js",
     "test": "node --expose-gc --max-old-space-size=1024 tests/main.js",

--- a/src/NodeClusterBase/MasterEndpoint.js
+++ b/src/NodeClusterBase/MasterEndpoint.js
@@ -55,7 +55,7 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 		this._bWorkersStarted = false;
 		this._bWatchingForUpgrade = false;
 
-		this.nMaxWorkersCount = Number.MAX_SAFE_INTEGER;
+		this._nMaxWorkersCount = Number.MAX_SAFE_INTEGER;
 	}
 
 
@@ -73,7 +73,7 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 	/**
 	 * @param {number} nWorkersCount
 	 */
-	set nMaxWorkersCount(nWorkersCount)
+	set maxWorkersCount(nWorkersCount)
 	{
 		assert(typeof nWorkersCount === "number", `Invalid property type for nWorkersCount in MasterEndpoint. Expected "number", but got ${typeof nWorkersCount}.`);
 
@@ -84,7 +84,7 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 	/**
 	 * @returns {number}
 	 */
-	get nMaxWorkersCount()
+	get maxWorkersCount()
 	{
 		return this._nMaxWorkersCount;
 	}
@@ -207,7 +207,7 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 
 		await this._startServices();
 
-		for (let i = 0; i < Math.min(Math.max(os.cpus().length, 1), this.nMaxWorkersCount); i++)
+		for (let i = 0; i < Math.min(Math.max(os.cpus().length, 1), this.maxWorkersCount); i++)
 		{
 			cluster.fork();
 		}

--- a/src/NodeClusterBase/MasterEndpoint.js
+++ b/src/NodeClusterBase/MasterEndpoint.js
@@ -55,7 +55,7 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 		this._bWorkersStarted = false;
 		this._bWatchingForUpgrade = false;
 
-		this._nMaxWorkersCount = Number.MAX_SAFE_INTEGER;
+		this.nMaxWorkersCount = Number.MAX_SAFE_INTEGER;
 	}
 
 
@@ -67,6 +67,26 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 	get workerClients()
 	{
 		return this.objWorkerIDToState;
+	}
+
+
+	/**
+	 * @param {number} nWorkersCount
+	 */
+	set nMaxWorkersCount(nWorkersCount)
+	{
+		assert(typeof nWorkersCount === "number", `Invalid property type for nWorkersCount in MasterEndpoint. Expected "number", but got ${typeof nWorkersCount}.`);
+
+		this._nMaxWorkersCount = nWorkersCount;
+	}
+
+
+	/**
+	 * @returns {number}
+	 */
+	get nMaxWorkersCount()
+	{
+		return this._nMaxWorkersCount;
 	}
 
 
@@ -187,7 +207,7 @@ class MasterEndpoint extends JSONRPC.EndpointBase
 
 		await this._startServices();
 
-		for (let i = 0; i < Math.min(Math.max(os.cpus().length, 1), this._nMaxWorkersCount); i++)
+		for (let i = 0; i < Math.min(Math.max(os.cpus().length, 1), this.nMaxWorkersCount); i++)
 		{
 			cluster.fork();
 		}


### PR DESCRIPTION
Now, the number of workers that are spawned is equal with numbers of cpus.
Added setter and getter for nMaxWorkersCount in case you want to have less workers.